### PR TITLE
Significantly refactor elisp code

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,15 @@ markup is available via quicklisp
 
 ## Editor support
 
-```lisp
+```emacs-lisp
 (use-package lisp-markup
-  :load-path "~/quicklisp/dists/quicklisp/software/markup-<version>-git/")
+  :load-path "~/quicklisp/dists/quicklisp/software/markup-<version>-git/"
+  :hook (lisp-mode . lisp-markup-minor-mode))
 
 ;; if you don't use use-package
 (add-to-list 'load-path "~/quicklisp/dists/quicklisp/software/markup-<version>-git/")
 (require 'lisp-markup)
+(add-hook 'lisp-mode-hook #'lisp-markup-minor-mode)
 ```
 
 ## FAQ

--- a/lisp-markup.el
+++ b/lisp-markup.el
@@ -1,84 +1,146 @@
 ;;;; lisp-markup.el
 ;;;; Charles Jackson
+(require 'cl-lib)
 (require 'sgml-mode)
 (require 'lisp-mode)
 
-(modify-syntax-entry ?' "." sgml-tag-syntax-table)
-(modify-syntax-entry ?' "." lisp-mode-syntax-table)
-(modify-syntax-entry 40 "|" sgml-tag-syntax-table)
-(modify-syntax-entry 41 "|" sgml-tag-syntax-table)
+(defvar lisp-markup-minor-mode-map
+  (let ((keymap (make-keymap)))
+    (define-key keymap (kbd "/") #'lisp-markup-/-close-tag)
+    (define-key keymap (kbd "C-c C-o") #'sgml-tag)
+    (define-key keymap (kbd "<return>") #'newline-and-indent)
+    keymap)
+  "Additional key bindings for `lisp-markup-minor-mode'.")
 
-(defmacro with-<>-as-brackets (&rest body)
+(defvar lisp-markup-sgml-tag-syntax-table
+  (let ((table (make-syntax-table sgml-tag-syntax-table)))
+    (modify-syntax-entry ?' "." table)
+    (modify-syntax-entry 40 "|" table)
+    (modify-syntax-entry 41 "|" table)
+    table)
+  "A modified `sgml-tag-syntax-table' that effectively ignores
+content between ?( and ?) by mapping them to symbol-escape
+characters. Additionally maps ?' to be a punctuation character
+which separates symbols.")
+
+(defvar *lisp-markup-mode-keywords*
+  '(("</?\\(:[^>/=[:space:]]+\\)" 1 font-lock-builtin-face)
+    ;; regular tag names
+    ("</?\\([^!>/=[:space:]]*\\)" 1 font-lock-function-name-face)
+    ;; attribute names
+    ("[[:space:]]\\([-[:alpha:]]+\\)=" 1 font-lock-constant-face)
+    ;; deftag faces
+    ("(\\(deftag\\)" 1 font-lock-keyword-face)
+    ("(deftag \\([^ ]+\\) " 1 font-lock-function-name-face)
+    ;; warning about single symbol lisp forms at the end of tags
+    ("=[^[:space:]<>]+[^\"/) ]\\(/\\|>\\)" 1 font-lock-warning-face)
+    ;; html comments
+    ("<!--.*-->" . font-lock-comment-face))
+  "`font-lock' configuration for `lisp-markup-minor-mode' to
+provide highlighting to HTML code within lisp files.")
+
+(define-minor-mode lisp-markup-minor-mode
+  "Enhance `lisp-mode' with additional features to support embedded HTML through markup.
+
+This changes syntax highlighting, indentation rules, and adds
+some extra keybindings to make editing of markup in lisp files
+easier."
+  :lighter " markup"
+  :keymap lisp-markup-minor-mode-map
+  (if (eq major-mode 'lisp-mode)
+      (if lisp-markup-minor-mode
+          (enter-lisp-markup-minor-mode)
+        (exit-lisp-markup-minor-mode))
+    (progn
+      (setf lisp-markup-minor-mode nil)
+      (error "lisp-markup-minor-mode only supports running in lisp-mode"))))
+
+(defun enter-lisp-markup-minor-mode ()
+  "Perform the setup required by `lisp-markup-minor-mode'."
+  (set-syntax-table (make-syntax-table (syntax-table)))
+  (modify-syntax-entry ?' ".")
+  (font-lock-add-keywords nil *lisp-markup-mode-keywords*)
+  (font-lock-update)
+  (setq-local indent-line-function #'lisp-markup-indent-line)
+  (setq-local indent-region-function #'lisp-markup-indent-region)
+  (sgml-electric-tag-pair-mode 1))
+
+(defun exit-lisp-markup-minor-mode ()
+  "Undo the setup performed by `enter-lisp-markup-minor-mode'."
+  (set-syntax-table lisp-mode-syntax-table)
+  (font-lock-remove-keywords nil *lisp-markup-mode-keywords*)
+  (font-lock-update)
+  (setq-local indent-line-function #'lisp-indent-line)
+  (setq-local indent-region-function #'lisp-indent-region)
+  (sgml-electric-tag-pair-mode -1))
+
+(defmacro lisp-markup-with-<>-as-brackets (&rest body)
+  "Run BODY in a context where ?< and ?> behave as brackets, and ?(
+and ?) behave as string delimiters. This is useful to run SGML
+functions on code that contains both Lisp and HTML."
   (declare (indent 0))
-  `(let* ((syntax-table (syntax-table))
-          (< (string (char-syntax ?<)))
-          (> (string (char-syntax ?>)))
-          (restore (lambda ()
-                     (modify-syntax-entry ?< < syntax-table)
-                     (modify-syntax-entry ?> > syntax-table)
-                     (modify-syntax-entry 40 "()" syntax-table)
-                     (modify-syntax-entry 41 ")(" syntax-table))))
-     (modify-syntax-entry ?< "(" syntax-table)
-     (modify-syntax-entry ?> ")" syntax-table)
-     (modify-syntax-entry 40 "\"" syntax-table)
-     (modify-syntax-entry 41 "\"" syntax-table)
-     (condition-case error
-         (progn ,@body)
-       (t
-        (funcall restore)
-        (error error)))
-     (funcall restore)))
+  `(with-syntax-table (make-syntax-table (syntax-table))
+     (modify-syntax-entry ?< "(")
+     (modify-syntax-entry ?> ")")
+     (modify-syntax-entry 40 "\"")
+     (modify-syntax-entry 41 "\"")
+     (progn ,@body)))
 
-;;; syntax highlighting
-(font-lock-add-keywords
- 'lisp-mode
- ;; keyword tag names
- '(("</?\\(:[^>/=[:space:]]+\\)" 1 font-lock-builtin-face)
-   ;; regular tag names
-   ("</?\\([^!>/=[:space:]]*\\)" 1 font-lock-function-name-face)
-   ;; attribute names
-   ("[[:space:]]\\([-[:alpha:]]+\\)=" 1 font-lock-constant-face)
-   ;; deftag faces
-   ("(\\(deftag\\)" 1 font-lock-keyword-face)
-   ("(deftag \\([^ ]+\\) " 1 font-lock-function-name-face)
-   ;; warning about single symbol lisp forms at the end of tags
-   ("=[^[:space:]<>]+[^\"/) ]\\(/\\|>\\)" 1 font-lock-warning-face)
-   ;; html comments
-   ("<!--.*-->" . font-lock-comment-face))
- 'prepend)
+(defmacro lisp-markup-with-sgml-tag-table (&rest body)
+  "Run BODY in a context where `sgml-tag-syntax-table' is resolved
+to be our custom syntax table. This allows us to run SGML
+functions which internally change the syntax table without them
+getting confused by Lisp code.."
+  `(let ((sgml-tag-syntax-table lisp-markup-sgml-tag-syntax-table))
+     ,@body))
 
-;;; context
-(defun in-html-p ()
+;;; Determining context
+;;; ===================
+
+(defun lisp-markup-in-html-p ()
+  "Is point currently in an HTML context?"
   (save-excursion
     (cl-loop
      with point = (point)
      for start = (progn (goto-char (or start point))
                         (when start (forward-char -1))
-                        (html-start-point))
-     while (/= start (point-max))
-     for end = (html-end-point)
+                        (lisp-markup-html-start-point))
+     while (/= start (point-min))
+     for end = (lisp-markup-html-end-point)
      if (<= start point end)
      return
      (progn
        (not (cl-loop
              for lisp-start = (progn (goto-char (or lisp-start point))
-                                (when lisp-start (forward-char -1))
-                                (lisp-start-point))
-             while (/= lisp-start (point-max))
-             for lisp-end = (lisp-end-point)
+                                     (when lisp-start (forward-char -1))
+                                     (lisp-markup-lisp-start-point))
+             while (/= lisp-start (point-min))
+             for lisp-end = (lisp-markup-lisp-end-point)
              if (<= start lisp-start (+ point 1) lisp-end end)
              return t))))))
-(defun lisp-start-point ()
+
+(defun lisp-markup-lisp-start-point ()
+  "Move backwards through the buffer, looking for the start of a
+Lisp code section. If one is found, move point there and return
+point. If none is found, return the minimum point."
   (condition-case nil
       (search-backward-regexp ",(\\|,@\\|=(")
-    (t (point-max))))
-(defun lisp-end-point ()
+    (t (point-min))))
+
+(defun lisp-markup-lisp-end-point ()
+  "Move to the closest Lisp end point, moving forwards from the
+current point. This function should only be called if point is at
+the beginning of a Lisp code section."
   (condition-case nil
       (progn (skip-chars-forward "=,@")
              (forward-sexp)
              (point))
     (t (point-max))))
-(defun html-start-point ()
+
+(defun lisp-markup-html-start-point ()
+  "Move backwards through the buffer, looking for the start of a
+HTML code section. If one is found, move point there and return
+point. If none is found, return the minimum point."
   (let ((html-start-re "<[^/=[:space:]()]"))
     (condition-case nil
         (if (looking-at-p html-start-re)
@@ -88,154 +150,146 @@
                        if (looking-at-p html-start-re)
                        return (point))))
             (if spot spot (point-max))))
-      (t (point-max)))))
-(defun html-end-point ()
-  (let ((tag-name (save-excursion
-                    (buffer-substring-no-properties
-                     (+ (point) 1) (- (search-forward-regexp "[>/[:space:]]") 1)))))
-    ;;; move to the end of this tag top
-    ;; move inside tag
-    (forward-char)
-    ;; move to end of tag or up to first attribute value
-    (while (not (member (char-before)
-                        '(?> ?=)))
-      (forward-char 1))
-    ;; move though attributes which should all be normal sexps
-    (while (/= ?> (char-before))
-      (forward-sexp)
-      (skip-chars-forward "\t\r\n ")
-      (skip-chars-forward "/>"))
-    (if (looking-back "/>" 1)
-        (point) ;; self closing tag: this is the end
-      (condition-case nil
-          (progn
-            (search-forward (concat "</" tag-name ">"))
-            (point))
-        (t (point-max))))
+      (t (point-min)))))
+
+(defun lisp-markup-html-end-point ()
+  "Move to the closest HTML end point, moving forwards from the
+current point. This function should only be called if point is at
+the beginning of a HTML code section."
+  (save-excursion
+    (lisp-markup-with-sgml-tag-table
+     (sgml-skip-tag-forward 1))
     (point)))
 
-;;; indentation
-(defun lisp-html-indent-line ()
-  "Indent a line of lisp or html."
+;;; Indentation
+;;; ===========
+
+(defun lisp-markup-indent-line ()
+  "Indent a line of Lisp or HTML, according to the line's context."
   (interactive)
   (save-excursion
-    (with-syntax-table (if (>= emacs-major-version 28)
-                           lisp-mode-syntax-table
-                           lisp--mode-syntax-table)
-      (back-to-indentation)
-      (let ((prev-html (save-excursion
-                         (forward-line -1)
-                         (end-of-line)
-                         (in-html-p)))
-            (beg-line-html (save-excursion
-                             (beginning-of-line)
-                             (in-html-p)))
-            (curr-html (in-html-p)))
-        (cond
-         ;; closing tag
-         ((looking-at "</")
-          (let* ((indent
-                  (save-excursion
-                    (forward-sexp 1)
-                    (sgml-skip-tag-backward 1)
-                    (- (point) (progn (beginning-of-line) (point))))))
-            (indent-line-to (max 0 indent))))
-         ;; after closing tag and end of lisp form
-         ((and prev-html
-               (save-excursion
-                 (forward-line -1)
-                 (end-of-line)
-                 (skip-chars-backward "\t\r\n ")
-                 (and (= (char-before) 41)
-                      (progn
-                        (forward-sexp -1)
-                        (skip-chars-backward ",@")
-                        (= (char-after) ?,)))))
-          (indent-line-to
-           (save-excursion
-             (forward-sexp -1)
-             (current-indentation))))
-         ;;
-         ((and prev-html
-               (save-excursion
-                 (forward-line -1)
-                 (back-to-indentation)
-                 (looking-at "</")))
-          (indent-line-to
-           (save-excursion
-             (forward-line -1)
-             (back-to-indentation)
-             (- (point) (progn (beginning-of-line) (point))))))
-         ;; sgml indent
-         (prev-html
-          ;; (message "html")
-          (with-<>-as-brackets
-            (sgml-indent-line)))
-         ;; lisp indent
-         (:else
-          (let ((indent (calculate-lisp-indent)))
-            ;; (message "lisp")
-            (cond
-             ((and indent (listp indent)) (indent-line-to (car indent)))
-             (indent (indent-line-to indent)))))))))
+    (lisp-markup-with-sgml-tag-table
+     (with-syntax-table (if (>= emacs-major-version 28)
+                            lisp-mode-syntax-table
+                          lisp--mode-syntax-table)
+       (back-to-indentation)
+       (let ((prev-html (save-excursion
+                          (forward-line -1)
+                          (end-of-line)
+                          (lisp-markup-in-html-p))))
+         (cond
+          ;; closing tag
+          ((looking-at "</")
+           (let* ((indent
+                   (save-excursion
+                     (forward-sexp 1)
+                     (sgml-skip-tag-backward 1)
+                     (- (point) (progn (beginning-of-line) (point))))))
+             (indent-line-to (max 0 indent))))
+          ;; after closing tag and end of lisp form
+          ((and prev-html
+                (save-excursion
+                  (forward-line -1)
+                  (end-of-line)
+                  (skip-chars-backward "\t\r\n ")
+                  (and (= (char-before) 41)
+                       (progn
+                         (forward-sexp -1)
+                         (skip-chars-backward ",@")
+                         (= (char-after) ?,)))))
+           (indent-line-to
+            (save-excursion
+              (forward-sexp -1)
+              (current-indentation))))
+          ;;
+          ((and prev-html
+                (save-excursion
+                  (forward-line -1)
+                  (back-to-indentation)
+                  (looking-at "</")))
+           (indent-line-to
+            (save-excursion
+              (forward-line -1)
+              (back-to-indentation)
+              (- (point) (progn (beginning-of-line) (point))))))
+          ;; sgml indent
+          (prev-html
+           (lisp-markup-with-<>-as-brackets
+             (sgml-indent-line)))
+          ;; lisp indent
+          (:else
+           (let ((indent (calculate-lisp-indent)))
+             (cond
+              ((and indent (listp indent)) (indent-line-to (car indent)))
+              (indent (indent-line-to indent))))))))))
   (when (< (point) (save-excursion (back-to-indentation) (point)))
     (back-to-indentation)))
-(defun lisp-html-indent-region (beg end)
-  "Indent a region of Lisp and Html mixed together.
-Just calls `lisp-html-indent-line' on every line of the region."
+
+(defun lisp-markup-indent-region (beg end)
+  "Indent the region of Lisp and HTML between BEG and END.
+
+This function just calls `lisp-markup-indent-line' on every line
+of the region."
   (interactive "r")
   (save-excursion
     (goto-char beg)
     (let ((last-line (line-number-at-pos end)))
       (cl-loop
-       do (lisp-html-indent-line)
+       do (lisp-markup-indent-line)
        do (forward-line 1)
        while (and (<= (line-number-at-pos (point)) last-line)
                   (<= (line-number-at-pos (point)) (line-number-at-pos (- (point-max) 1))))))))
-;; set indentation functions in hooks
-(defun set-lisp-html-indentation ()
-  (setq indent-line-function #'lisp-html-indent-line)
-  (setq indent-region-function #'lisp-html-indent-region))
-(add-hook 'lisp-mode-hook #'set-lisp-html-indentation)
-;; define enter to indent
-(define-key lisp-mode-map (kbd "<return>") #'newline-and-indent)
 
-;;; neato stuff
-(defun html-closed-p ()
-  "Call this when point is before starting angle bracket."
-    (save-excursion
-      (html-end-point)
-      (when (looking-back "</[^\t\r\n </>]*>\\|/>" 1)
-        (point))))
+;;; Automatic tag closing
+;;; =====================
 
-(defun html-close-tag ()
+(defun lisp-markup-html-closed-p ()
+  "Test whether the current HTML tag has a corresponding closing tag.
+
+This method must be called with point before the opening < of a tag."
+  (save-excursion
+    (lisp-markup-with-sgml-tag-table
+     (when (sgml-skip-tag-forward 1)
+       (point)))))
+
+(defun lisp-markup-html-close-tag ()
+  "Insert a closing tag for the nearest tag before point that is unclosed.
+
+This function only looks backwards to find unclosed tags, and
+thus a tag that is closed further forwards in the file will not
+be considered. Hence in an example like this:
+
+  <div>
+    <span></span>
+    |
+  </div>
+
+with point at |, a </div> will be inserted."
   (interactive)
-  (let* ((point (point))
-         (tag-name
+  (insert "</"
           (save-excursion
-            (cl-loop while (/= (point-max) (html-start-point))
-                     for close = (html-closed-p)
+            (cl-loop with initial = (point)
+                     while (/= (point-max) (lisp-markup-html-start-point))
+                     for close = (lisp-markup-html-closed-p)
                      if (or (not close)
-                            (<= point close))
+                            (<= initial close))
                      return (buffer-substring-no-properties
                              (+ (point) 1)
                              (- (search-forward-regexp "[>/[:space:]]") 1))
-                     do (forward-char -1)))))
-    (insert "</" tag-name ">")))
+                     do (forward-char -1)))
+          ">"))
 
-(defun html-/-close-tag ()
+(defun lisp-markup-/-close-tag ()
+  "Automatically insert a closing tag if this character was typed
+after a <. Otherwise, just insert a /."
   (interactive)
   (insert "/")
   (when (= ?< (char-before (1- (point))))
     (backward-delete-char 2)
-    (html-close-tag)
+    (lisp-markup-html-close-tag)
     (when (= ?> (or (char-after) 0))
       (delete-char 1))
-    (lisp-html-indent-line)))
-
-(define-key lisp-mode-map (kbd "/") #'html-/-close-tag)
-(define-key lisp-mode-map (kbd "C-c C-o") #'sgml-tag)
-(add-hook 'lisp-mode-hook #'sgml-electric-tag-pair-mode)
+    (lisp-markup-indent-line)))
 
 (provide 'lisp-markup)
 ;;; lisp-markup.el ends here


### PR DESCRIPTION
Hi there! I was taking a look at markup because I've been considering building something like this myself for a while. It looks great!

I noticed that your elisp code was modifying the underlying `lisp-mode` structures, which seemed a bit dirty. The usual mechanism to add functionality to a major mode is to write a minor mode, so I went through the motions of converting the elisp code into a `lisp-markup-minor-mode`. In the process of doing that I saw a bunch of other things I wanted to change, too, and so this PR is the result of that.

It's a more drastic change than I was expecting to make when I started, but I think the way that it finds enclosing Lisp/HTML sections is a bit simpler overall. It also no longer relies on `cl-lib`, and I've tested that it loads and runs how I expect in `emacs -Q`.