### PR TITLE
Enhance Emacs support for comments/sexps

### DIFF
--- a/lisp-markup.el
+++ b/lisp-markup.el
@@ -194,7 +194,7 @@ returns a pair of start and `point-max'. If no start is found,
 returns nil."
   (lisp-markup-find-enclosing
    (lambda ()
-     (search-backward-regexp "<[^/=[:space:]()]"))
+     (search-backward-regexp "<[^/=![:space:]()]"))
    (lambda ()
      (lisp-markup-with-sgml-tag-table
       (or (sgml-skip-tag-forward 1)

--- a/lisp-markup.el
+++ b/lisp-markup.el
@@ -61,7 +61,7 @@ easier."
   (font-lock-add-keywords nil *lisp-markup-mode-keywords*)
   (font-lock-update)
   (setq-local indent-line-function #'lisp-markup-indent-line)
-  (setq-local indent-region-function #'lisp-markup-indent-region)
+  (setq-local indent-region-function #'indent-region-line-by-line) ; Less efficient, but still correct
   (sgml-electric-tag-pair-mode 1))
 
 (defun exit-lisp-markup-minor-mode ()
@@ -236,19 +236,6 @@ returns nil."
   (when (< (point) (save-excursion (back-to-indentation) (point)))
     (back-to-indentation)))
 
-(defun lisp-markup-indent-region (beg end)
-  "Indent the region of Lisp and HTML between BEG and END.
-
-This function just calls `lisp-markup-indent-line' on every line
-of the region."
-  (interactive "r")
-  (save-excursion
-    (let ((end (copy-marker end)))
-      (goto-char beg)
-      (while (< (point) end)
-        (beginning-of-line)
-        (lisp-markup-indent-line)
-        (forward-line 1)))))
 
 ;;; Automatic tag closing
 ;;; =====================

--- a/lisp-markup.el
+++ b/lisp-markup.el
@@ -217,7 +217,7 @@ returns nil."
                           (lisp-markup-in-html-p))))
          (cond
           ;; closing tag
-          ((looking-at "</")
+          ((looking-at-p "</")
            (let* ((indent
                    (save-excursion
                      (forward-sexp 1)
@@ -244,7 +244,7 @@ returns nil."
                 (save-excursion
                   (forward-line -1)
                   (back-to-indentation)
-                  (looking-at "</")))
+                  (looking-at-p "</")))
            (indent-line-to
             (save-excursion
               (forward-line -1)
@@ -297,7 +297,11 @@ still pretty useful."
         (let ((forward-sexp-function nil))
           (forward-sexp n interactive))))
      ((< n 0)
-      (if (looking-back "[^[:space:]'()]>[[:space:]\n]*")
+      (if (save-excursion (let ((whitespace-chars (string-to-list " \t\r\n")))
+                            (while (member (char-before) whitespace-chars)
+                              (backward-char)))
+                          (backward-char 2)
+                          (looking-at-p "[^[:space:]'()]>"))
 	  (lisp-markup-with-sgml-tag-table
            (sgml-skip-tag-backward (- n)))
         (let ((forward-sexp-function nil))
@@ -356,9 +360,10 @@ with point at |, a </div> will be inserted."
 after a <. Otherwise, just insert a /."
   (interactive)
   (insert "/")
-  (when (looking-back "</")
+  (when (save-excursion (backward-char 2)
+                        (looking-at-p "</"))
     (insert (lisp-markup-find-unclosed-tag-name))
-    (unless (looking-at ">")
+    (unless (looking-at-p ">")
       (insert ">"))
     (lisp-markup-indent-line)))
 

--- a/lisp-markup.el
+++ b/lisp-markup.el
@@ -152,6 +152,8 @@ Returns a pair of beginning and end points, or NOT-FOUND."
         (while t
           (let* ((start (or (ignore-errors
                               (funcall find-start)
+                              (while (nth 4 (syntax-ppss)) ; is in a comment
+                                (funcall find-start))      ; so keep looking
                               (point))
                             (throw 'return not-found)))
                  (end (or (ignore-errors


### PR DESCRIPTION
Hi again!

This change is building off my last one, and making the HTML support feel a bit more integrated into Emacs. These changes are a bit more controversial than my other PR, but I think broadly make sense.

These changes are trying to achieve two things:
1. make `C-M-f`, `C-M-b`, and `C-M-t` play nicely with HTML sections - treating entire tags as complete s-expressions when it makes sense to do so; and
2. make `comment-dwim` (i.e. `M-;`), and other commenting functions, aware of what kind of text they're in so they can comment appropriately

This is intentionally changing behaviour, so it might require a bit more hands-on experience before merging, to make sure it "feels right".